### PR TITLE
make cards clickable 

### DIFF
--- a/checks.yaml
+++ b/checks.yaml
@@ -3,16 +3,19 @@
     - name: GitHub Home
       type: http
       host: https://github.com
+      url: https://docs.github.com/en
       expected_code: 200
 
     - name: GitHub API
       type: http
       host: https://api.github.com
+      url: https://api.github.com/users
       expected_code: 200
 
     - name: Wikipedia Home
       type: http
       host: https://www.wikipedia.org
+      url: https://en.wikipedia.org/wiki/Main_Page
       expected_code: 200
 
     - name: Wikipedia API

--- a/index.html.theme
+++ b/index.html.theme
@@ -31,6 +31,21 @@
                 --footer-color: #888;
                 --link-color: #5dade2;
             }
+            a,
+            a:link,
+            a:visited {
+                cursor: pointer;
+                color: rgb(144, 202, 249);
+                text-decoration: none !important;
+                -webkit-transition: color 1s ease, background-color 1s ease;
+                -moz-transition: color 1s ease, background-color 1s ease;
+                -o-transition: color 1s ease, background-color 1s ease;
+                transition: color 1s ease, background-color 1s ease;
+            }
+            a:hover {
+                color: #b2ebf2;
+                background-color: #424242;
+            }
         }
         body {
             font-family: sans-serif;
@@ -85,6 +100,23 @@
             text-decoration: none;
         }
         .footer a:hover { text-decoration: underline; }
+         a,
+        a:link,
+        a:visited {
+            cursor: pointer;
+            color: rgb(35, 148, 218);
+            text-decoration: none !important;
+            -webkit-transition: color 1s ease, background-color 1s ease;
+            -moz-transition: color 1s ease, background-color 1s ease;
+            -o-transition: color 1s ease, background-color 1s ease;
+            transition: color 1s ease, background-color 1s ease;
+        }
+
+        a:hover {
+            color: #86b692;
+            background-color: #daffcf;
+        }
+
     </style>
 </head>
 <body>
@@ -95,7 +127,7 @@
     <div class="status-grid">
         {% for check in checks %}
         <div class="status-item">
-            <h3>{{ check.name }}</h3>
+            <h3><a target="_blank" href="{{ check.url }}">{{ check.name }}</a></h3>
             <p class="{% if check.status %}status-up{% else %}status-down{% endif %}">
                 {{ 'Operational' if check.status else 'Down' }}
             </p>

--- a/index.html.theme
+++ b/index.html.theme
@@ -39,7 +39,7 @@
                 text-decoration: none !important;
             }
             a:hover {
-                color: white;
+                color: lightgray ! important;
             }
         }
         body {

--- a/index.html.theme
+++ b/index.html.theme
@@ -37,14 +37,9 @@
                 cursor: pointer;
                 color: rgb(144, 202, 249);
                 text-decoration: none !important;
-                -webkit-transition: color 1s ease, background-color 1s ease;
-                -moz-transition: color 1s ease, background-color 1s ease;
-                -o-transition: color 1s ease, background-color 1s ease;
-                transition: color 1s ease, background-color 1s ease;
             }
             a:hover {
-                color: #b2ebf2;
-                background-color: #424242;
+                color: white;
             }
         }
         body {
@@ -106,15 +101,10 @@
             cursor: pointer;
             color: rgb(35, 148, 218);
             text-decoration: none !important;
-            -webkit-transition: color 1s ease, background-color 1s ease;
-            -moz-transition: color 1s ease, background-color 1s ease;
-            -o-transition: color 1s ease, background-color 1s ease;
-            transition: color 1s ease, background-color 1s ease;
         }
 
         a:hover {
             color: #86b692;
-            background-color: #daffcf;
         }
 
     </style>
@@ -126,12 +116,14 @@
     <h3>{{group}} Status</h3>
     <div class="status-grid">
         {% for check in checks %}
+        <a target="_blank" href="{{ check.url }}">
         <div class="status-item">
-            <h3><a target="_blank" href="{{ check.url }}">{{ check.name }}</a></h3>
+                <h3>{{ check.name }}</h3>
             <p class="{% if check.status %}status-up{% else %}status-down{% endif %}">
                 {{ 'Operational' if check.status else 'Down' }}
             </p>
         </div>
+        </a>
         {% endfor %}
     </div>
     {% endfor %}

--- a/index.html.theme
+++ b/index.html.theme
@@ -10,7 +10,7 @@
     <link rel="manifest" href="assets/site.webmanifest">
     <link rel="mask-icon" href="assets/safari-pinned-tab.svg" color="#5bbad5">
     <meta name="msapplication-TileColor" content="#da532c">
-    <meta name="theme-color" content="#ffffff"> 
+    <meta name="theme-color" content="#ffffff">
     <style>
         :root {
             --bg-color: #f4f4f4;
@@ -35,11 +35,11 @@
             a:link,
             a:visited {
                 cursor: pointer;
-                color: rgb(144, 202, 249);
+                color: rgb(128, 128, 128);
                 text-decoration: none !important;
             }
             a:hover {
-                color: lightgray ! important;
+                color: white !important;
             }
         }
         body {
@@ -99,12 +99,12 @@
         a:link,
         a:visited {
             cursor: pointer;
-            color: rgb(35, 148, 218);
+            color: rgb(51, 51, 51);
             text-decoration: none !important;
         }
 
         a:hover {
-            color: #86b692;
+            color: rgb(86, 86, 86);
         }
 
     </style>
@@ -116,14 +116,18 @@
     <h3>{{group}} Status</h3>
     <div class="status-grid">
         {% for check in checks %}
-        <a target="_blank" href="{{ check.url }}">
+            {% if check.url %}
+                <a target="_blank" href="{{ check.url }}">
+            {% endif %}
         <div class="status-item">
-                <h3>{{ check.name }}</h3>
+            <h3>{{ check.name }}</h3>
             <p class="{% if check.status %}status-up{% else %}status-down{% endif %}">
                 {{ 'Operational' if check.status else 'Down' }}
             </p>
         </div>
-        </a>
+            {% if check.url %}
+                </a>
+            {% endif %}
         {% endfor %}
     </div>
     {% endfor %}

--- a/tinystatus.py
+++ b/tinystatus.py
@@ -72,7 +72,7 @@ async def run_checks(checks):
     results = [
         {
             "name": check["name"],
-            "url": check.get("url", check.get("host")),
+            "url": check.get("url"),
             "status": background_tasks[check["name"]].result()}
         for check in checks
     ]

--- a/tinystatus.py
+++ b/tinystatus.py
@@ -68,7 +68,10 @@ async def run_checks(checks):
                 background_tasks[check['name']] = task
 
     results = [
-        {"name": check["name"], "status": background_tasks[check["name"]].result()}
+        {
+            "name": check["name"],
+            "url": check.get("url", check.get("host")),
+            "status": background_tasks[check["name"]].result()}
         for check in checks
     ]
 


### PR DESCRIPTION
It's a frequent use case to need to navigate to a service rather than just displaying its status. This will also allow using the status page as some kind of 'dashboard' that allows navigating to services.

For entries of `type: ping` the `url` could, for example, point to some kind of configuration page or whatever the user finds appropriate.

The PR adds the `url` key to `checks.yaml` which can point, for example, to the service main page or some custom troubleshooting URL. If the key is missing then the value of the `host` key is used as a fallback.

Example:

```yaml

    - name: Wikipedia Home
      type: http
      host: https://www.wikipedia.org
      url: https://en.wikipedia.org/wiki/Main_Page
      expected_code: 200
```